### PR TITLE
Latency improvement for llama-index

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -17,3 +17,4 @@ scikit-learn==1.2.1
 llama-index==0.4.35.post1
 sse_starlette==1.3.3
 gpt-index==0.5.16
+faiss-cpu==1.7.3


### PR DESCRIPTION
Minor change to make llama-index faster using FAISS.

Tested locally:
`curl -X POST -F "files=@Docs/0333_text.txt" -F "num_eval_questions=1" -F "chunk_chars=1000" -F "overlap=100" -F "split_method=RecursiveTextSplitter" -F "retriver_type=Llama-Index" -F "embeddings=OpenAI" -F "model_version=gpt-3.5-turbo" -F "grade_prompt=Fast" -F "num_neighbors=3" http://localhost:8000/evaluator-stream`