### PR TITLE
Keep descriptive outputs

### DIFF
--- a/api/evaluator_app.py
+++ b/api/evaluator_app.py
@@ -319,8 +319,8 @@ def run_evaluator(
         d['latency'] = latency
         
         # Summary statistics
-        d['answerScore'] = [1 if "INCORRECT" not in text else 0 for text in d['answerScore']]
-        d['retrievalScore'] = [1 if "Context is relevant: True" in text else 0 for text in d['retrievalScore']]
+        d['answerScoreBinary'] = [1 if "INCORRECT" not in text else 0 for text in d['answerScore']]
+        d['retrievalScoreBinary'] = [1 if "Context is relevant: True" in text else 0 for text in d['retrievalScore']]
 
         # Convert dataframe to dict
         d_dict = d.to_dict('records')


### PR DESCRIPTION
`answerScore` and `retrievalScore` descriptive outputs can be kept as collapsible columns in the table.

They will be verbose if `grade_prompt != "Fast"`.

You can see the templates [here](https://github.com/dankolesnikov/evaluator-app/blob/1fc1831a06cafc4c43bd3a6c9cb01677ecb6a103/api/text_utils.py#L65).

`GRADE_DOCS_PROMPT` will ask the model to explain itself:

```
template = """ 
    Given the question: \n
    {query}
    Decide if the following retreived context is relevant: \n
    {result}
    Answer in the following format: \n
    "Context is relevant: True or False." \n 
    And explain why it supports or does not support the correct answer: {answer}"""

GRADE_DOCS_PROMPT = PromptTemplate(input_variables=["query", "result", "answer"], template=template)
```