### PR TITLE
Add OpenAI grading prompt

### DIFF
--- a/api/evaluator_app.py
+++ b/api/evaluator_app.py
@@ -384,7 +384,7 @@ def run_evaluator(
         # Summary statistics
         d['answerScore'] = [{'score': 1 if "INCORRECT" not in text else 0,
                              'justification': text} for text in d['answerScore']]
-        d['retrievalScore'] = [{'score': 1 if "Context is relevant: True" in text else 0,
+        d['retrievalScore'] = [{'score': 1 if "INCORRECT" not in text else 0,
                                 'justification': text} for text in d['retrievalScore']]
 
         # Convert dataframe to dict

--- a/api/text_utils.py
+++ b/api/text_utils.py
@@ -58,19 +58,19 @@ template = """
     {query}
     Decide if the following retreived context is relevant: \n
     {result}
-    Answer in the following format: \n
-    "Context is relevant: True or False." \n 
-    And explain why it supports or does not support the correct answer: {answer}"""
+    Explain why the retreived context supports or does not support the correct answer: \n {answer} \n
+    Then print "CORRECT" if the retreived context supports the answer or "INCORRECT" if it does not (without quotes or punctuation) on its own line."""
 
 GRADE_DOCS_PROMPT = PromptTemplate(input_variables=["query", "result", "answer"], template=template)
 
 template = """ 
     Given the question: \n
     {query}
-    Decide if the following retreived context is relevant to the {answer}: \n
+    And the answer: \n 
+    {answer}
+    Decide if the following retreived supports or does not support the answer: \n
     {result}
-    Answer in the following format: \n
-    "Context is relevant: True or False." \n """
+    Print "CORRECT" if the retreived context supports the answer or "INCORRECT" if it does not (without quotes or punctuation) on its own line. """
 
 GRADE_DOCS_PROMPT_FAST = PromptTemplate(input_variables=["query", "result", "answer"], template=template)
 
@@ -110,7 +110,7 @@ template = """You are assessing a submitted student answer to a question relativ
       conciseness:  Is the answer concise and to the point?"
       correct: Is the answer correct?"
     ***
-    Does the submission meet the criterion? First, write out in a step by step manner your reasoning about the criterion to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print the "CORRECT" or "INCORRECT" (without quotes or punctuation) on its own line corresponding to the correct answer.
+    Does the submission meet the criterion? First, write out in a step by step manner your reasoning about the criterion to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print "CORRECT" or "INCORRECT" (without quotes or punctuation) on its own line corresponding to the correct answer.
     Reasoning:
 """
 


### PR DESCRIPTION
1/ OAI prompt -
https://github.com/openai/evals/blob/main/evals/registry/modelgraded/closedqa.yaml

2/ Also, I see bug - 
`Avg Retrieval Relevancy Score` is 1 with `FAST` but `0.6` with `DESCRIPTIVE`.

The regex grading for `Context is relevant: True` is ugly.

Clean this up using the same approach that the above OAI prompt uses.

And have `Retrieval Relevancy Score` output CORRECT or INCORRECT just like answer scoring.

![image](https://user-images.githubusercontent.com/122662504/234183258-a3a0d01a-0d07-49ae-a4ea-365cd438c491.png)