### PR TITLE
Fix expt summary refresh

### DIFF
--- a/nextjs/components/Demo.tsx
+++ b/nextjs/components/Demo.tsx
@@ -125,7 +125,8 @@ const Demo = ({ form }: { form: Form }) => {
     setLoading(true);
     setResults([]);
 
-    if (data.evalQuestionsCount !== evalQuestionsCount) {
+    const resetExpts = data.evalQuestionsCount !== evalQuestionsCount;
+    if (resetExpts) {
       setExperiments([]);
     }
 
@@ -216,9 +217,11 @@ const Demo = ({ form }: { form: Form }) => {
       avgAnswerScore,
       avgLatency,
       performance: avgAnswerScore / avgLatency,
-      id: experiments.length + 1,
+      id: resetExpts ? 1 : experiments.length + 1,
     };
-    setExperiments((experiments) => [...experiments, newExperiment]);
+    setExperiments((experiments) =>
+      resetExpts ? [newExperiment] : [...experiments, newExperiment]
+    );
   });
 
   const download = useCallback(

--- a/nextjs/components/Playground.tsx
+++ b/nextjs/components/Playground.tsx
@@ -115,10 +115,9 @@ const Playground = ({ form }: { form: Form }) => {
     setLoading(true);
     setResults([]);
 
-    if (
-      didUploadTestDataset ||
-      data.evalQuestionsCount !== evalQuestionsCount
-    ) {
+    const resetExpts =
+      data.evalQuestionsCount !== evalQuestionsCount || didUploadTestDataset;
+    if (resetExpts) {
       setExperiments([]);
     }
 
@@ -210,9 +209,11 @@ const Playground = ({ form }: { form: Form }) => {
       avgAnswerScore,
       avgLatency,
       performance: avgAnswerScore / avgLatency,
-      id: experiments.length + 1,
+      id: resetExpts ? 1 : experiments.length + 1,
     };
-    setExperiments((experiments) => [...experiments, newExperiment]);
+    setExperiments((experiments) =>
+      resetExpts ? [newExperiment] : [...experiments, newExperiment]
+    );
   });
 
   const runExperimentButtonLabel = experiments.length


### PR DESCRIPTION
See linked ticket for info. The problem was that since the form submission button is a callback, it does not receive state updates after being initially executed. In this case, it did not receive its own update to state of refreshing the expts table. This fix is janky but this code requires a refactor asap anyway.