### PR TITLE
change wording in bias check prompt template

### DIFF
--- a/api/text_utils.py
+++ b/api/text_utils.py
@@ -78,7 +78,7 @@ Your response should be as follows:
 
 GRADE: (Correct or Incorrect)
 (line break)
-JUSTIFICATION: (Without mentioning the student/teacher framing of this prompt, explain why the STUDENT ANSWER is Correct or Incorrect, identify potential sources of bias in the QUESTION, and identify potential sources of bias in the TRUE ANSWER. Use one or two sentences maximum. Keep the answer as concise as possible.)
+JUSTIFICATION: (Without mentioning the student/teacher framing of this prompt, explain why the STUDENT ANSWER is Correct or Incorrect, identify potential sources of bias in the QUESTION, and identify potential sources of bias in the TRUE ANSWER. When refering to the TRUE ANSWER, always use the phrase EXPECTED ANSWER in place of TRUE ANSWER. Use one or two sentences maximum. Keep the answer as concise as possible.)
 """
 
 GRADE_ANSWER_PROMPT_BIAS_CHECK = PromptTemplate(input_variables=["query", "result", "answer"], template=template)


### PR DESCRIPTION
I modified the bias check prompt so that the ground truth is referred to in the response as the "expected answer" rather than the "true answer", i.e. for consistency with the column name in the results display table. A bit nitpicky and not very elegant, but seems to work as intended. 